### PR TITLE
Update compilation target for tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ES2020", "ES2021.String"],
-    "target": "es5",
+    "target": "ES2015",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
I'm updating compilation target in order to fix issue with extending for custom errors, for example this code:

```js
class SomeError extends Error {
}

const error = new SomeError();

console.log(error instanceof SomeError);
```

was producing ```false```, cause of known issue related es5: https://github.com/microsoft/TypeScript/issues/49587.

Possible fixes for this issue:
1. Update target to es6
2. Do some manupulations with prototype and hope that we will not face with that issue somewhere else.

So I've decided to updade target version, cause this version is supported almost by all browsers: https://caniuse.com/es6